### PR TITLE
Fix getContext and use of camelcase in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Creates an Ubidots instance.
 
 ## Methods
 
-`void add(const char *variable_label, float value, char *context, unsigned long dot_timestamp_seconds, unsigned int dot_timestamp_millis)`
+`void add(const char *variable_label, float value, char *context, unsigned long dotTimestampSeconds, unsigned int dotTimestampMillis)`
 
 Adds a dot with its related value, context and timestamp to be sent to a certain data source.
 
@@ -60,15 +60,15 @@ Adds a dot with its related value, context and timestamp to be sent to a certain
 - @variable_label, [Required]. The label of the variable where the dot will be stored.
 - @value, [Required]. The value of the dot.
 - @context, [Optional]. The dot's context.
-- @dot_timestamp_seconds, [Optional]. The dot's timestamp in seconds.
-- @dot_timestamp_millis, [Optional]. The dot's timestamp number of milliseconds. If the timestamp's milliseconds values is not set, the seconds will be multplied by 1000.
+- @dotTimestampSeconds, [Optional]. The dot's timestamp in seconds.
+- @dotTimestampMillis, [Optional]. The dot's timestamp number of milliseconds. If the timestamp's milliseconds values is not set, the seconds will be multplied by 1000.
 
-`void addContext(char *key_label, char *key_value)`
+`void addContext(char *keyLabel, char *keyValue)`
 
 Adds to local memory a new key-value context key. The method inputs must be char pointers. The method allows to store up to 10 key-value pairs.
 
-- @key_label, [Required]. The key context label to store values.
-- @key_value, [Required]. The key pair value.
+- @keyLabel, [Required]. The key context label to store values.
+- @keyValue, [Required]. The key pair value.
 
 `void getContext(char *context)`
 

--- a/src/UbiTypes.h
+++ b/src/UbiTypes.h
@@ -30,8 +30,8 @@ typedef struct Value {
 } Value;
 
 typedef struct ContextUbi {
-  char *key_label;
-  char *key_value;
+  char *keyLabel;
+  char *keyValue;
 } ContextUbi;
 
 #endif

--- a/src/UbidotsEsp32Mqtt.cpp
+++ b/src/UbidotsEsp32Mqtt.cpp
@@ -276,7 +276,7 @@ void Ubidots::addContext(char* key_label, char* key_value) {
 void Ubidots::getContext(char* context_result) {
   sprintf(context_result, "");
   for (uint8_t i = 0; i < _current_context;) {
-    sprintf(context_result, "%s\"%s\":%s", context_result, (_context + i)->key_label, (_context + i)->key_value);
+    sprintf(context_result, "%s\"%s\":\"%s\"", context_result, (_context + i)->key_label, (_context + i)->key_value);
     i++;
     if (i < _current_context) {
       sprintf(context_result, "%s,", context_result);

--- a/src/UbidotsEsp32Mqtt.h
+++ b/src/UbidotsEsp32Mqtt.h
@@ -30,14 +30,14 @@ Created by: Jose Garcia @jotathebest at github: https://github.com/jotathebest
 class Ubidots {
  private:
   // void (*callback)(char*, uint8_t*, unsigned int);
-  WiFiClient _client_tcp_ubi;
-  PubSubClient _client_mqtt_ubi = PubSubClient(_client_tcp_ubi);
+  WiFiClient _clientTcpUbi;
+  PubSubClient _clientMqttUbi = PubSubClient(_clientTcpUbi);
   char* _broker;
   ContextUbi* _context;
   char* _clientName;
   int _brokerPort;
   bool _debug = false;
-  int8_t _current_context = 0;
+  int8_t _currentContext = 0;
   uint8_t _currentValue;
   char* _ssidPassword;
   char* _ssid;
@@ -55,17 +55,17 @@ class Ubidots {
   ~Ubidots();
   void add(const char* variableLabel, float value);
   void add(const char* variableLabel, float value, char* context);
-  void add(const char* variableLabel, float value, char* context, unsigned long dot_timestamp_seconds);
-  void add(const char* variableLabel, float value, char* context, unsigned long dot_timestamp_seconds,
-           unsigned int dot_timestamp_millis);
-  void addContext(char* key_label, char* key_value);
+  void add(const char* variableLabel, float value, char* context, unsigned long dotTimestampSeconds);
+  void add(const char* variableLabel, float value, char* context, unsigned long dotTimestampSeconds,
+           unsigned int dotTimestampMillis);
+  void addContext(char* keyLabel, char* keyValue);
   bool connected();
   bool connect();
   bool connect(const char* username, const char* password);
   bool connect(const char* clientName, const char* username, const char* password);
   void connectToWifi(const char* ssid, const char* pass);
   void disconnect();
-  void getContext(char* context_result);
+  void getContext(char* contextResult);
   bool loop();
   bool publish();
   bool publish(const char* deviceLabel);


### PR DESCRIPTION
1. Context send strings as values 
2. Use of camelcase in variables