### PR TITLE
:bug: fixed passing unsigned long value to abs function

### DIFF
--- a/examples/publish/publish.ino
+++ b/examples/publish/publish.ino
@@ -67,7 +67,7 @@ void loop()
   {
     ubidots.reconnect();
   }
-  if (abs(millis() - timer) > PUBLISH_FREQUENCY) // triggers the routine every 5 seconds
+  if ((millis() - timer) > PUBLISH_FREQUENCY) // triggers the routine every 5 seconds
   {
     float value = analogRead(analogPin);
     ubidots.add(VARIABLE_LABEL, value); // Insert your variable Labels and the value to be sent

--- a/examples/subscribeAndpublish/subscribeAndpublish.ino
+++ b/examples/subscribeAndpublish/subscribeAndpublish.ino
@@ -70,7 +70,7 @@ void loop()
     ubidots.reconnect();
     ubidots.subscribeLastValue(SUBSCRIBE_DEVICE_LABEL, SUBSCRIBE_VARIABLE_LABEL); // Insert the device and variable's Labels, respectively
   }
-  if (abs(millis() - timer) > PUBLISH_FREQUENCY) // triggers the routine every 5 seconds
+  if ((millis() - timer) > PUBLISH_FREQUENCY) // triggers the routine every 5 seconds
   {
     float value = analogRead(analogPin);
     ubidots.add(PUBLISH_VARIABLE_LABEL, value); // Insert your variable Labels and the value to be sent


### PR DESCRIPTION
Fixed the "call of overloaded 'abs(long unsigned int)' is ambiguous" error by removing unnecessary abs() function from millis() timing comparisons.